### PR TITLE
Fix problems with CI

### DIFF
--- a/templates/config/application.example.yml
+++ b/templates/config/application.example.yml
@@ -6,7 +6,7 @@ APP_PORT: '3000'
 MAIL_HOST: ''
 MAIL_USERNAME: ''
 MAIL_PASSWORD: ''
-MAIL_SENDER: <yourname>+<application>@renuo.ch
+MAIL_SENDER: 'yourname+<application>@example.com' # change your name and domain to @renuo.ch
 
 # Secrets
 SECRET_KEY_BASE: 'rake secret'
@@ -36,7 +36,7 @@ RENUO_UPLOAD_APP_NAME: '<application>-<branch>'
 
 # This is used to seed your database
 # Use a random password for develop/master/testing
-ADMIN_EMAIL: <yourname>+<application>@renuo.ch
+ADMIN_EMAIL: 'yourname+<application>@example.com' # change your name and domain to @renuo.ch
 ADMIN_PASSWORD: 'developer'
 
 # Have 3 different Google Analytics key so not to mix up data from different applications

--- a/templates/config/application.example.yml
+++ b/templates/config/application.example.yml
@@ -6,7 +6,7 @@ APP_PORT: '3000'
 MAIL_HOST: ''
 MAIL_USERNAME: ''
 MAIL_PASSWORD: ''
-MAIL_SENDER: 'yourname+application@example.com' # change your name and domain to @renuo.ch
+MAIL_SENDER: 'yourname+<application>@example.com' # change your name and domain to @renuo.ch
 
 # Secrets
 SECRET_KEY_BASE: 'rake secret'
@@ -36,7 +36,7 @@ RENUO_UPLOAD_APP_NAME: '<application>-<branch>'
 
 # This is used to seed your database
 # Use a random password for develop/master/testing
-ADMIN_EMAIL: 'yourname+application@example.com' # change your name and domain to @renuo.ch
+ADMIN_EMAIL: 'yourname+<application>@example.com' # change your name and domain to @renuo.ch
 ADMIN_PASSWORD: 'developer'
 
 # Have 3 different Google Analytics key so not to mix up data from different applications

--- a/templates/config/application.example.yml
+++ b/templates/config/application.example.yml
@@ -6,7 +6,7 @@ APP_PORT: '3000'
 MAIL_HOST: ''
 MAIL_USERNAME: ''
 MAIL_PASSWORD: ''
-MAIL_SENDER: 'yourname+<application>@example.com' # change your name and domain to @renuo.ch
+MAIL_SENDER: 'yourname+application@example.com' # change your name and domain to @renuo.ch
 
 # Secrets
 SECRET_KEY_BASE: 'rake secret'
@@ -36,7 +36,7 @@ RENUO_UPLOAD_APP_NAME: '<application>-<branch>'
 
 # This is used to seed your database
 # Use a random password for develop/master/testing
-ADMIN_EMAIL: 'yourname+<application>@example.com' # change your name and domain to @renuo.ch
+ADMIN_EMAIL: 'yourname+application@example.com' # change your name and domain to @renuo.ch
 ADMIN_PASSWORD: 'developer'
 
 # Have 3 different Google Analytics key so not to mix up data from different applications


### PR DESCRIPTION
we have problems with the ci, if we use <yourname> in the example. what happens is:

* ci copies the application.example.yml to  application.yml
* in the application.yml now we had an entry ADMIN_EMAIL: '<yourname>+sampleapp@renuo.ch' (not a valid mail)
* we can discuss if it makes sense to compare against ENV or if it should be mocked. but now tests comparing to `ENV['ADMIN_EMAIL']` will return a different mail. While locally it works, when have changed the `<yourname>`, on the CI it is not an array: 

```
       expected: ["<yourname>+sampleapp@example.com"]
            got: "<yourname>+sampleapp@example.com"
```

i would recommend to change it!