### PR TITLE
avoid to override defaults

### DIFF
--- a/templates/.rubocop_base.yml
+++ b/templates/.rubocop_base.yml
@@ -13,6 +13,10 @@ Style/NonNilCheck:
 Metrics/BlockLength:
   Exclude:
   - config/initializers/simple_form_bootstrap.rb
+  - 'Rakefile'
+  - '**/*.rake'
+  - 'spec/**/*.rb'
+
 
 Style/FileName:
   Exclude:


### PR DESCRIPTION
https://github.com/bbatsov/rubocop/blob/master/manual/configuration.md#inheritance

says that 

> Configuration parameter that are hashes, for example PreferredMethods in Style/CollectionMethods are merged with the same parameter in the base configuration, while other parameter, such as AllCops / Include, are simply replaced by the local setting.